### PR TITLE
Check definition lists

### DIFF
--- a/debug.css
+++ b/debug.css
@@ -149,3 +149,14 @@ input[type=submit][value]{
 [id]{
 	outline:5px solid yellow;
 }
+
+/**
+ * Definition lists should only contain DT and DD elements
+ */
+dl > * {
+    outline:5px solid red;
+}
+dl > dt,
+dl > dd {
+    outline:none;
+}


### PR DESCRIPTION
I see definition lists containing invalid markup quite a bit. This should probably be a check
